### PR TITLE
Allow fixtures to successfully implement ContainerAwareInterface

### DIFF
--- a/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
@@ -9,6 +9,7 @@ namespace VIPSoft\DoctrineDataFixturesExtension\Service;
 use Symfony\Component\HttpKernel\Kernel;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader as DataFixturesLoader;
 
@@ -136,6 +137,9 @@ class FixtureService
 
             if (! class_exists($className, false)) {
                 $fixture = new $className;
+                if ($fixture instanceof ContainerAwareInterface) {
+                    $fixture->setContainer($this->kernel->getContainer());
+                }
                 $fixtures[get_class($fixture)] = $fixture;
             }
         }


### PR DESCRIPTION
This patch injects Symfony's container into the fixture as per the behaviour expected from `app/console doctrine:fixtures:load`

This allows more complex fixtures (e.g. those making use of FOSUserBundle or similar services) to be loaded individually (with autoload: false)

The code mimics the code found in `Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php` (around line 79) 
