### PR TITLE
Use fixture file modification timestamps and reuse backed up data between behat invocations

### DIFF
--- a/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
@@ -253,10 +253,6 @@ class FixtureService
      */
     private function backupFixtures()
     {
-        $cacheDirectory = $this->kernel->getContainer()->getParameter('kernel.cache_dir');
-
-        $this->backupDbFile = $cacheDirectory . '/test_' . $this->generateHash($this->fixtures) . '.db';
-
         copy($this->databaseFile, $this->backupDbFile);
     }
 
@@ -285,6 +281,12 @@ class FixtureService
         $this->fixtures = $this->fetchFixtures();
 
         $this->databaseFile = $this->getDatabaseFile();
+
+        if (isset($this->databaseFile)) {
+            $cacheDirectory = $this->kernel->getContainer()->getParameter('kernel.cache_dir');
+
+            $this->backupDbFile = $cacheDirectory . '/test_' . $this->generateHash($this->fixtures) . '.db';
+        }
     }
 
     /**


### PR DESCRIPTION
Added mtime for fixture files to the hash calculation. Added code to check for backed up file before initial fixture data load - now should properly detect if any fixture file changed between behat invocations.
