### PR TITLE
Added the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,18 @@
     ],
     "require": {
         "php": ">=5.3.6",
-        "behat/behat": ">=2.4.0,<3.0",
-        "behat/symfony2-extension": ">=1.0",
+        "behat/behat": ">=2.4.0,<3.0-dev",
+        "behat/symfony2-extension": "~1.0",
         "symfony/config": ">=2.0.0,<3.0-dev",
         "symfony/dependency-injection": ">=2.0.0,<3.0-dev",
         "doctrine/data-fixtures": "dev-master"
     },
     "autoload": {
         "psr-0": { "VIPSoft\\DoctrineDataFixturesExtension": "src/" }
+    },
+    "extras": {
+        "branch-alias": {
+            "dev-master": "0.9.x-dev"
+        }
     }
 }


### PR DESCRIPTION
This adds a branch alias for master so that it matches constraints like `0.9.*`.

I also fixed the requirements to use a bound constraint for the symfony extension and to exclude Behat 3.0 properly (the previous constraint would allow the beta releases as they are lower than 3.0)
