### PR TITLE
Fixed the branch alias for master and the data-fixtures constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         "behat/symfony2-extension": "~1.0",
         "symfony/config": ">=2.0.0,<3.0-dev",
         "symfony/dependency-injection": ">=2.0.0,<3.0-dev",
-        "doctrine/data-fixtures": "dev-master"
+        "doctrine/data-fixtures": "~1.0"
     },
     "autoload": {
         "psr-0": { "VIPSoft\\DoctrineDataFixturesExtension": "src/" }
     },
     "extras": {
         "branch-alias": {
-            "dev-master": "0.9.x-dev"
+            "dev-master": "0.10.x-dev"
         }
     }
 }


### PR DESCRIPTION
this bumps the branch alias for master as the latest tag is 0.10 whereas I thought it would be 0.9.16

I also changed the requirement for doctrine/data-fixtures to use a bound constraint. dev-master still matches thanks to its branch alias, but this makes it compatible with the 1.0.0 stable tag too
