### PR TITLE
Reference Aware Behat Contexts

### DIFF
--- a/src/VIPSoft/DoctrineDataFixturesExtension/Context/FixtureServiceAwareContextInterface.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Context/FixtureServiceAwareContextInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace VIPSoft\DoctrineDataFixturesExtension\Context;
+
+use VIPSoft\DoctrineDataFixturesExtension\Service\FixtureService;
+
+/**
+ * Interface FixtureServiceAwareContextInterface
+ *
+ * @package VIPSoft\DoctrineDataFixturesExtension\Context
+ */
+interface FixtureServiceAwareContextInterface
+{
+    /**
+     * Set the FixtureService
+     *
+     * @param FixtureService $service
+     * @return mixed
+     */
+    public function setFixtureService(FixtureService $service);
+}

--- a/src/VIPSoft/DoctrineDataFixturesExtension/Context/Initializer/FixtureServiceAwareInitializer.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Context/Initializer/FixtureServiceAwareInitializer.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace VIPSoft\DoctrineDataFixturesExtension\Context\Initializer;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\Initializer\ContextInitializer;
+use VIPSoft\DoctrineDataFixturesExtension\Context\FixtureServiceAwareContextInterface;
+use VIPSoft\DoctrineDataFixturesExtension\Service\FixtureService;
+
+/**
+ * Class FixtureServiceAwareInitializer
+ *
+ * @package VIPSoft\DoctrineDataFixturesExtension\Context\Initializer
+ */
+class FixtureServiceAwareInitializer implements ContextInitializer
+{
+    /**
+     * @var FixtureService
+     */
+    private $fixtureService;
+
+    /**
+     * Constructor
+     *
+     */
+    public function __construct(FixtureService $fixtureService)
+    {
+        $this->fixtureService = $fixtureService;
+    }
+
+    /**
+     * Initializes provided context.
+     *
+     * @param Context $context
+     */
+    public function initializeContext(Context $context)
+    {
+        if (!$context instanceof FixtureServiceAwareContextInterface && !$this->usesReferenceDictionary($context)) {
+            return;
+        }
+
+        $context->setFixtureService($this->fixtureService);
+    }
+
+    /**
+     * Checks whether the context uses the ReferenceDictionary trait.
+     *
+     * @param Context $context
+     *
+     * @return boolean
+     */
+    private function usesReferenceDictionary(Context $context)
+    {
+        $refl = new \ReflectionObject($context);
+
+        if (! method_exists($refl, 'getTraitNames')) {
+            return false;
+        }
+
+        if (! in_array('VIPSoft\DoctrineDataFixturesExtension\Context\ReferenceDictionary', $refl->getTraitNames())) {
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/src/VIPSoft/DoctrineDataFixturesExtension/Context/ReferenceDictionary.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Context/ReferenceDictionary.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace VIPSoft\DoctrineDataFixturesExtension\Context;
+
+use VIPSoft\DoctrineDataFixturesExtension\Service\FixtureService;
+
+/**
+ * Class ReferenceDictionary
+ *
+ * @package VIPSoft\DoctrineDataFixturesExtension\Context
+ */
+trait ReferenceDictionary
+{
+    /**
+     * @var FixtureService
+     */
+    private $fixtureService;
+
+    /**
+     * Sets the Reference Repository
+     *
+     * @param FixtureService $service
+     */
+    public function setFixtureService(FixtureService $service)
+    {
+        $this->fixtureService = $service;
+    }
+
+    /**
+     * Returns the Reference Repository
+     *
+     * @return FixtureService
+     */
+    public function getFixtureService()
+    {
+        return $this->fixtureService;
+    }
+
+    /**
+     * Takes a reference string and returns the entity created in fixtures
+     *
+     * @param string $reference
+     * @return object
+     */
+    public function getReference($reference)
+    {
+        return $this->fixtureService->getReferenceRepository()->getReference($reference);
+    }
+
+    /**
+     * Checks if the reference is known to the Repository
+     *
+     * @param string $reference
+     * @return object
+     */
+    public function hasReference($reference)
+    {
+        return $this->fixtureService->getReferenceRepository()->hasReference($reference);
+    }
+}

--- a/src/VIPSoft/DoctrineDataFixturesExtension/Resources/config/services.xml
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Resources/config/services.xml
@@ -6,6 +6,7 @@
     <parameters>
         <parameter key="behat.doctrine_data_fixtures.service.hook_listener.class">VIPSoft\DoctrineDataFixturesExtension\EventListener\HookListener</parameter>
         <parameter key="behat.doctrine_data_fixtures.service.fixture_loader.class">VIPSoft\DoctrineDataFixturesExtension\Service\FixtureService</parameter>
+        <parameter key="behat.doctrine_data_fixtures.initializer.fixture_service_aware.class">VIPSoft\DoctrineDataFixturesExtension\Context\Initializer\FixtureServiceAwareInitializer</parameter>
     </parameters>
 
     <services>
@@ -21,6 +22,11 @@
             <argument type="service" id="service_container" />
             <argument type="service" id="symfony2_extension.kernel" />
             <argument>%behat.doctrine_data_fixtures.use_backup%</argument>
+        </service>
+
+        <service id="behat.doctrine_data_fixtures.initializer.fixture_service_aware" class="%behat.doctrine_data_fixtures.initializer.fixture_service_aware.class%">
+            <argument type="service" id="behat.doctrine_data_fixtures.service.fixture_loader"/>
+            <tag name="context.initializer"/>
         </service>
     </services>
 


### PR DESCRIPTION
- Added `FixtureServiceAwareContextInterface` that allow contexts to reach the fixtureService
- Added a trait for easy implementation that allows resolving references
- Made use for the ProxyReferenceRepository and its caching habilities to cache references along with DB (recommend Doctrine 2.5+ for bug fixes)

Closes #25.
