### PR TITLE
Usage of configurated mysql port with mysqldump

### DIFF
--- a/src/VIPSoft/DoctrineDataFixturesExtension/Service/Backup/MysqlDumpBackup.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Service/Backup/MysqlDumpBackup.php
@@ -73,6 +73,10 @@ class MysqlDumpBackup implements BackupInterface
             $command .= sprintf(" -p%s", escapeshellarg($params['password']));
         }
 
+        if (isset($params['port'])) {
+            $command .= sprintf(" -P%s", escapeshellarg($params['port']));
+        }
+
         $this->runCommand($command);
     }
 
@@ -95,6 +99,10 @@ class MysqlDumpBackup implements BackupInterface
             $command .= sprintf(" -p%s", escapeshellarg($params['password']));
         }
 
+        if (isset($params['port'])) {
+            $command .= sprintf(" -P%s", escapeshellarg($params['port']));
+        }
+        
         $this->runCommand($command);
     }
 }


### PR DESCRIPTION
I needed to use a different port than the default one (3306).
It has been tested on my project with port 3323 and seems to work properly.
