### PR TITLE
drop database setting

### DIFF
--- a/src/VIPSoft/DoctrineDataFixturesExtension/Extension.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Extension.php
@@ -65,9 +65,9 @@ class Extension implements ExtensionInterface
                 ->booleanNode('use_backup')
                     ->defaultValue(true)
                 ->end()
-	            ->booleanNode('drop_database')
-	                ->defaultValue(true)
-	            ->end()
+                ->booleanNode('drop_database')
+                    ->defaultValue(true)
+                ->end()
             ->end();
     }
 

--- a/src/VIPSoft/DoctrineDataFixturesExtension/Extension.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Extension.php
@@ -65,6 +65,9 @@ class Extension implements ExtensionInterface
                 ->booleanNode('use_backup')
                     ->defaultValue(true)
                 ->end()
+	            ->booleanNode('drop_database')
+	                ->defaultValue(true)
+	            ->end()
             ->end();
     }
 
@@ -90,6 +93,7 @@ class Extension implements ExtensionInterface
         $container->setParameter('behat.doctrine_data_fixtures.lifetime', $config['lifetime']);
         $container->setParameter('behat.doctrine_data_fixtures.migrations', $config['migrations']);
         $container->setParameter('behat.doctrine_data_fixtures.use_backup', $config['use_backup']);
+        $container->setParameter('behat.doctrine_data_fixtures.drop_database', $config['drop_database']);
     }
 
     /**

--- a/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
@@ -38,6 +38,7 @@ class FixtureService
     private $entityManager;
     private $listener;
     private $useBackup;
+	private $hasToDropDatabase;
     private $backupService;
 
     /**
@@ -53,12 +54,13 @@ class FixtureService
      */
     public function __construct(ContainerInterface $container, Kernel $kernel)
     {
-        $this->autoload    = $container->getParameter('behat.doctrine_data_fixtures.autoload');
-        $this->fixtures    = $container->getParameter('behat.doctrine_data_fixtures.fixtures');
-        $this->directories = $container->getParameter('behat.doctrine_data_fixtures.directories');
-        $this->migrations  = $container->getParameter('behat.doctrine_data_fixtures.migrations');
-        $this->useBackup   = $container->getParameter('behat.doctrine_data_fixtures.use_backup');
-        $this->kernel      = $kernel;
+        $this->autoload          = $container->getParameter('behat.doctrine_data_fixtures.autoload');
+        $this->fixtures          = $container->getParameter('behat.doctrine_data_fixtures.fixtures');
+        $this->directories       = $container->getParameter('behat.doctrine_data_fixtures.directories');
+        $this->migrations        = $container->getParameter('behat.doctrine_data_fixtures.migrations');
+        $this->useBackup         = $container->getParameter('behat.doctrine_data_fixtures.use_backup');
+	    $this->hasToDropDatabase = $container->getParameter('behat.doctrine_data_fixtures.drop_database');
+        $this->kernel            = $kernel;
 
         if ($this->useBackup) {
             $this->backupService = $container->get('behat.doctrine_data_fixtures.service.backup');
@@ -394,7 +396,9 @@ class FixtureService
         $this->fixtures   = $this->fetchFixtures();
 
         if ($this->useBackup && ! $this->hasBackup()) {
-            $this->dropDatabase();
+	        if ($this->hasToDropDatabase) {
+		        $this->dropDatabase();
+	        }
         }
     }
 
@@ -461,8 +465,10 @@ class FixtureService
         }
 
         if ($this->migrations === null) {
-            $this->dropDatabase();
-            $this->createDatabase();
+	        if ($this->hasToDropDatabase) {
+		        $this->dropDatabase();
+		        $this->createDatabase();
+	        }
         }
 
         $this->loadFixtures();

--- a/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
@@ -38,7 +38,7 @@ class FixtureService
     private $entityManager;
     private $listener;
     private $useBackup;
-	private $hasToDropDatabase;
+    private $hasToDropDatabase;
     private $backupService;
 
     /**
@@ -59,7 +59,7 @@ class FixtureService
         $this->directories       = $container->getParameter('behat.doctrine_data_fixtures.directories');
         $this->migrations        = $container->getParameter('behat.doctrine_data_fixtures.migrations');
         $this->useBackup         = $container->getParameter('behat.doctrine_data_fixtures.use_backup');
-	    $this->hasToDropDatabase = $container->getParameter('behat.doctrine_data_fixtures.drop_database');
+        $this->hasToDropDatabase = $container->getParameter('behat.doctrine_data_fixtures.drop_database');
         $this->kernel            = $kernel;
 
         if ($this->useBackup) {
@@ -396,9 +396,9 @@ class FixtureService
         $this->fixtures   = $this->fetchFixtures();
 
         if ($this->useBackup && ! $this->hasBackup()) {
-	        if ($this->hasToDropDatabase) {
-		        $this->dropDatabase();
-	        }
+            if ($this->hasToDropDatabase) {
+                $this->dropDatabase();
+            }
         }
     }
 
@@ -465,10 +465,10 @@ class FixtureService
         }
 
         if ($this->migrations === null) {
-	        if ($this->hasToDropDatabase) {
-		        $this->dropDatabase();
-		        $this->createDatabase();
-	        }
+            if ($this->hasToDropDatabase) {
+                $this->dropDatabase();
+                $this->createDatabase();
+            }
         }
 
         $this->loadFixtures();


### PR DESCRIPTION
I've created this pull request to meet the requirements explained by an old issue I created some time ago.

https://github.com/vipsoft/DoctrineDataFixturesExtension/issues/37

This we let us to choose whether to drop the database or not. It could be useful for applications with a database that is not entirely mapped in doctrine2. In my specific case, I'm working on a project with plenty of legacy code written with Symfony1 so not all the tables have to be dropped and still they are necessary to run the tests. One of them is for example the **user table** that is necessary to initiate a session.